### PR TITLE
Implement deeper Drawflow interop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,51 @@
-﻿[![](https://img.shields.io/nuget/v/soenneker.blazor.drawflow.svg?style=for-the-badge)](https://www.nuget.org/packages/soenneker.blazor.drawflow/)
+[![](https://img.shields.io/nuget/v/soenneker.blazor.drawflow.svg?style=for-the-badge)](https://www.nuget.org/packages/soenneker.blazor.drawflow/)
 [![](https://img.shields.io/github/actions/workflow/status/soenneker/soenneker.blazor.drawflow/publish-package.yml?style=for-the-badge)](https://github.com/soenneker/soenneker.blazor.drawflow/actions/workflows/publish-package.yml)
 [![](https://img.shields.io/nuget/dt/soenneker.blazor.drawflow.svg?style=for-the-badge)](https://www.nuget.org/packages/soenneker.blazor.drawflow/)
 
 # ![](https://user-images.githubusercontent.com/4441470/224455560-91ed3ee7-f510-4041-a8d2-3fc093025112.png) Soenneker.Blazor.Drawflow
-### A Blazor interop library for drawflow.js
+A lightweight Blazor wrapper for [drawflow.js](https://github.com/jerosoler/Drawflow).
 
 ## Installation
+```bash
+ dotnet add package Soenneker.Blazor.Drawflow
+```
 
+## Usage
+Include the Drawflow library on the page and drop the component:
+```html
+<link href="https://cdn.jsdelivr.net/npm/drawflow/dist/drawflow.min.css" rel="stylesheet" />
+<script src="https://cdn.jsdelivr.net/npm/drawflow/dist/drawflow.min.js"></script>
 ```
-dotnet add package Soenneker.Blazor.Drawflow
+```razor
+<Drawflow @ref="Flow" Options="_options" OnNodeCreated="Handle" style="height:400px"></Drawflow>
+
+@code {
+    private Drawflow? Flow;
+    private readonly DrawflowOptions _options = new();
+
+    private Task Handle(string id)
+    {
+        Console.WriteLine($"Node created {id}");
+        return Task.CompletedTask;
+    }
+}
 ```
+
+See the demo project for a working example.
+
+### Additional helpers
+
+The component exposes many of the functions provided by drawflow.js. Some useful helpers include:
+
+```razor
+@ref Flow
+```
+
+```csharp
+await Flow.ZoomIn();
+await Flow.ZoomOut();
+await Flow.AddModule("Other");
+await Flow.ChangeModule("Other");
+```
+
+There are also methods for manipulating inputs/outputs, removing connections and clearing modules.

--- a/src/Abstract/IDrawflowInterop.cs
+++ b/src/Abstract/IDrawflowInterop.cs
@@ -1,8 +1,43 @@
-﻿namespace Soenneker.Blazor.Drawflow.Abstract;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.JSInterop;
+using Microsoft.AspNetCore.Components;
+using Soenneker.Blazor.Drawflow.Options;
+
+namespace Soenneker.Blazor.Drawflow.Abstract;
 
 /// <summary>
 /// A Blazor interop library for drawflow.js
 /// </summary>
 public interface IDrawflowInterop
 {
+    ValueTask Create(string elementId, DrawflowOptions? options = null, CancellationToken cancellationToken = default);
+    ValueTask AddNode(string elementId, string name, int inputs, int outputs, int posX, int posY, string className, object? data, string html, CancellationToken cancellationToken = default);
+    ValueTask RemoveNode(string elementId, string nodeId, CancellationToken cancellationToken = default);
+    ValueTask AddConnection(string elementId, string outputNode, string inputNode, string outputClass, string inputClass, CancellationToken cancellationToken = default);
+    ValueTask<string> Export(string elementId, CancellationToken cancellationToken = default);
+    ValueTask Import(string elementId, string json, CancellationToken cancellationToken = default);
+    ValueTask Destroy(string elementId, CancellationToken cancellationToken = default);
+    ValueTask AddEventListener(string elementId, string eventName, EventCallback<string> callback, CancellationToken cancellationToken = default);
+
+    ValueTask ZoomIn(string elementId, CancellationToken cancellationToken = default);
+    ValueTask ZoomOut(string elementId, CancellationToken cancellationToken = default);
+
+    ValueTask AddModule(string elementId, string name, CancellationToken cancellationToken = default);
+    ValueTask ChangeModule(string elementId, string name, CancellationToken cancellationToken = default);
+    ValueTask RemoveModule(string elementId, string name, CancellationToken cancellationToken = default);
+
+    ValueTask<IJSObjectReference?> GetNodeFromId(string elementId, string id, CancellationToken cancellationToken = default);
+    ValueTask<int[]> GetNodesFromName(string elementId, string name, CancellationToken cancellationToken = default);
+    ValueTask UpdateNodeData(string elementId, string id, object data, CancellationToken cancellationToken = default);
+    ValueTask AddNodeInput(string elementId, string id, CancellationToken cancellationToken = default);
+    ValueTask AddNodeOutput(string elementId, string id, CancellationToken cancellationToken = default);
+    ValueTask RemoveNodeInput(string elementId, string id, string inputClass, CancellationToken cancellationToken = default);
+    ValueTask RemoveNodeOutput(string elementId, string id, string outputClass, CancellationToken cancellationToken = default);
+    ValueTask RemoveSingleConnection(string elementId, string outId, string inId, string outClass, string inClass, CancellationToken cancellationToken = default);
+    ValueTask UpdateConnectionNodes(string elementId, string id, CancellationToken cancellationToken = default);
+    ValueTask RemoveConnectionNodeId(string elementId, string id, CancellationToken cancellationToken = default);
+    ValueTask<string?> GetModuleFromNodeId(string elementId, string id, CancellationToken cancellationToken = default);
+    ValueTask ClearModuleSelected(string elementId, CancellationToken cancellationToken = default);
+    ValueTask Clear(string elementId, CancellationToken cancellationToken = default);
 }

--- a/src/Drawflow.razor
+++ b/src/Drawflow.razor
@@ -1,0 +1,84 @@
+@using Microsoft.Extensions.Logging
+@using Microsoft.JSInterop
+@using Microsoft.AspNetCore.Components
+@using Soenneker.Blazor.Drawflow.Options
+@using Soenneker.Blazor.Drawflow.Abstract
+@implements IAsyncDisposable
+@inject IDrawflowInterop Interop
+@inject ILogger<Drawflow> Logger
+
+<div blazor-interop-id="@_elementId" style="width:100%;height:100%;"></div>
+
+@code {
+    private readonly string _elementId = "df_" + Guid.NewGuid().ToString("N");
+
+    [Parameter]
+    public DrawflowOptions? Options { get; set; }
+
+    [Parameter]
+    public EventCallback<string> OnNodeCreated { get; set; }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await Interop.Create(_elementId, Options);
+            await RegisterEvents();
+        }
+    }
+
+    private async Task RegisterEvents()
+    {
+        if (OnNodeCreated.HasDelegate)
+        {
+            await Interop.AddEventListener(_elementId, "nodeCreated", EventCallback.Factory.Create<string>(this, OnNodeCreated));
+        }
+    }
+
+    public ValueTask AddNode(string name, int inputs, int outputs, int posX, int posY, string className, object? data, string html)
+    {
+        return Interop.AddNode(_elementId, name, inputs, outputs, posX, posY, className, data, html);
+    }
+
+    public ValueTask AddConnection(string outputNode, string inputNode, string outputClass, string inputClass)
+    {
+        return Interop.AddConnection(_elementId, outputNode, inputNode, outputClass, inputClass);
+    }
+
+    public ValueTask RemoveNode(string nodeId) => Interop.RemoveNode(_elementId, nodeId);
+
+    public ValueTask RemoveConnectionNodeId(string nodeId) => Interop.RemoveConnectionNodeId(_elementId, nodeId);
+
+    public ValueTask<string> Export() => Interop.Export(_elementId);
+
+    public ValueTask Import(string json) => Interop.Import(_elementId, json);
+
+    public ValueTask ZoomIn() => Interop.ZoomIn(_elementId);
+    public ValueTask ZoomOut() => Interop.ZoomOut(_elementId);
+
+    public ValueTask AddModule(string name) => Interop.AddModule(_elementId, name);
+    public ValueTask ChangeModule(string name) => Interop.ChangeModule(_elementId, name);
+    public ValueTask RemoveModule(string name) => Interop.RemoveModule(_elementId, name);
+
+    public ValueTask AddNodeInput(string id) => Interop.AddNodeInput(_elementId, id);
+    public ValueTask AddNodeOutput(string id) => Interop.AddNodeOutput(_elementId, id);
+    public ValueTask RemoveNodeInput(string id, string inputClass) => Interop.RemoveNodeInput(_elementId, id, inputClass);
+    public ValueTask RemoveNodeOutput(string id, string outputClass) => Interop.RemoveNodeOutput(_elementId, id, outputClass);
+
+    public ValueTask RemoveSingleConnection(string outId, string inId, string outClass, string inClass) =>
+        Interop.RemoveSingleConnection(_elementId, outId, inId, outClass, inClass);
+
+    public ValueTask Clear() => Interop.Clear(_elementId);
+
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            await Interop.Destroy(_elementId);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error disposing Drawflow");
+        }
+    }
+}

--- a/src/DrawflowInterop.cs
+++ b/src/DrawflowInterop.cs
@@ -1,19 +1,198 @@
-﻿using Soenneker.Blazor.Drawflow.Abstract;
+using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
+using Soenneker.Blazor.Drawflow.Abstract;
+using Soenneker.Blazor.Drawflow.Options;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Soenneker.Blazor.Drawflow;
 
 /// <inheritdoc cref="IDrawflowInterop"/>
-public sealed class DrawflowInterop: IDrawflowInterop
+public sealed class DrawflowInterop : IDrawflowInterop
 {
     private readonly IJSRuntime _jsRuntime;
     private readonly ILogger<DrawflowInterop> _logger;
+    private IJSObjectReference? _module;
 
-    public DrawflowInterop(IJSRuntime jSRuntime, ILogger<DrawflowInterop> logger)
+    public DrawflowInterop(IJSRuntime jsRuntime, ILogger<DrawflowInterop> logger)
     {
-        _jsRuntime = jSRuntime;
+        _jsRuntime = jsRuntime;
         _logger = logger;
+    }
+
+    private async ValueTask<IJSObjectReference> Module()
+    {
+        if (_module is null)
+        {
+            _module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import", "./_content/Soenneker.Blazor.Drawflow/js/drawflowinterop.js");
+        }
+        return _module;
+    }
+
+    public async ValueTask Create(string elementId, DrawflowOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var module = await Module();
+        await module.InvokeVoidAsync("create", cancellationToken, elementId, options);
+    }
+
+    public async ValueTask AddNode(string elementId, string name, int inputs, int outputs, int posX, int posY, string className, object? data, string html, CancellationToken cancellationToken = default)
+    {
+        var module = await Module();
+        await module.InvokeVoidAsync("addNode", cancellationToken, elementId, name, inputs, outputs, posX, posY, className, data, html);
+    }
+
+    public async ValueTask RemoveNode(string elementId, string nodeId, CancellationToken cancellationToken = default)
+    {
+        var module = await Module();
+        await module.InvokeVoidAsync("removeNode", cancellationToken, elementId, nodeId);
+    }
+
+    public async ValueTask AddConnection(string elementId, string outputNode, string inputNode, string outputClass, string inputClass, CancellationToken cancellationToken = default)
+    {
+        var module = await Module();
+        await module.InvokeVoidAsync("addConnection", cancellationToken, elementId, outputNode, inputNode, outputClass, inputClass);
+    }
+
+    public async ValueTask<string> Export(string elementId, CancellationToken cancellationToken = default)
+    {
+        var module = await Module();
+        return await module.InvokeAsync<string>("export", cancellationToken, elementId);
+    }
+
+    public async ValueTask Import(string elementId, string json, CancellationToken cancellationToken = default)
+    {
+        var module = await Module();
+        await module.InvokeVoidAsync("import", cancellationToken, elementId, json);
+    }
+
+    public async ValueTask Destroy(string elementId, CancellationToken cancellationToken = default)
+    {
+        if (_module is null)
+            return;
+        await _module.InvokeVoidAsync("destroy", cancellationToken, elementId);
+    }
+
+    public async ValueTask AddEventListener(string elementId, string eventName, EventCallback<string> callback, CancellationToken cancellationToken = default)
+    {
+        var module = await Module();
+        var dotNet = DotNetObjectReference.Create(new CallbackInvoker(callback));
+        await module.InvokeVoidAsync("addEventListener", cancellationToken, elementId, eventName, dotNet);
+    }
+
+    public async ValueTask ZoomIn(string elementId, CancellationToken cancellationToken = default)
+    {
+        var module = await Module();
+        await module.InvokeVoidAsync("zoomIn", cancellationToken, elementId);
+    }
+
+    public async ValueTask ZoomOut(string elementId, CancellationToken cancellationToken = default)
+    {
+        var module = await Module();
+        await module.InvokeVoidAsync("zoomOut", cancellationToken, elementId);
+    }
+
+    public async ValueTask AddModule(string elementId, string name, CancellationToken cancellationToken = default)
+    {
+        var module = await Module();
+        await module.InvokeVoidAsync("addModule", cancellationToken, elementId, name);
+    }
+
+    public async ValueTask ChangeModule(string elementId, string name, CancellationToken cancellationToken = default)
+    {
+        var module = await Module();
+        await module.InvokeVoidAsync("changeModule", cancellationToken, elementId, name);
+    }
+
+    public async ValueTask RemoveModule(string elementId, string name, CancellationToken cancellationToken = default)
+    {
+        var module = await Module();
+        await module.InvokeVoidAsync("removeModule", cancellationToken, elementId, name);
+    }
+
+    public async ValueTask<IJSObjectReference?> GetNodeFromId(string elementId, string id, CancellationToken cancellationToken = default)
+    {
+        var module = await Module();
+        return await module.InvokeAsync<IJSObjectReference?>("getNodeFromId", cancellationToken, elementId, id);
+    }
+
+    public async ValueTask<int[]> GetNodesFromName(string elementId, string name, CancellationToken cancellationToken = default)
+    {
+        var module = await Module();
+        return await module.InvokeAsync<int[]>("getNodesFromName", cancellationToken, elementId, name);
+    }
+
+    public async ValueTask UpdateNodeData(string elementId, string id, object data, CancellationToken cancellationToken = default)
+    {
+        var module = await Module();
+        await module.InvokeVoidAsync("updateNodeData", cancellationToken, elementId, id, data);
+    }
+
+    public async ValueTask AddNodeInput(string elementId, string id, CancellationToken cancellationToken = default)
+    {
+        var module = await Module();
+        await module.InvokeVoidAsync("addNodeInput", cancellationToken, elementId, id);
+    }
+
+    public async ValueTask AddNodeOutput(string elementId, string id, CancellationToken cancellationToken = default)
+    {
+        var module = await Module();
+        await module.InvokeVoidAsync("addNodeOutput", cancellationToken, elementId, id);
+    }
+
+    public async ValueTask RemoveNodeInput(string elementId, string id, string inputClass, CancellationToken cancellationToken = default)
+    {
+        var module = await Module();
+        await module.InvokeVoidAsync("removeNodeInput", cancellationToken, elementId, id, inputClass);
+    }
+
+    public async ValueTask RemoveNodeOutput(string elementId, string id, string outputClass, CancellationToken cancellationToken = default)
+    {
+        var module = await Module();
+        await module.InvokeVoidAsync("removeNodeOutput", cancellationToken, elementId, id, outputClass);
+    }
+
+    public async ValueTask RemoveSingleConnection(string elementId, string outId, string inId, string outClass, string inClass, CancellationToken cancellationToken = default)
+    {
+        var module = await Module();
+        await module.InvokeVoidAsync("removeSingleConnection", cancellationToken, elementId, outId, inId, outClass, inClass);
+    }
+
+    public async ValueTask UpdateConnectionNodes(string elementId, string id, CancellationToken cancellationToken = default)
+    {
+        var module = await Module();
+        await module.InvokeVoidAsync("updateConnectionNodes", cancellationToken, elementId, id);
+    }
+
+    public async ValueTask RemoveConnectionNodeId(string elementId, string id, CancellationToken cancellationToken = default)
+    {
+        var module = await Module();
+        await module.InvokeVoidAsync("removeConnectionNodeId", cancellationToken, elementId, id);
+    }
+
+    public async ValueTask<string?> GetModuleFromNodeId(string elementId, string id, CancellationToken cancellationToken = default)
+    {
+        var module = await Module();
+        return await module.InvokeAsync<string?>("getModuleFromNodeId", cancellationToken, elementId, id);
+    }
+
+    public async ValueTask ClearModuleSelected(string elementId, CancellationToken cancellationToken = default)
+    {
+        var module = await Module();
+        await module.InvokeVoidAsync("clearModuleSelected", cancellationToken, elementId);
+    }
+
+    public async ValueTask Clear(string elementId, CancellationToken cancellationToken = default)
+    {
+        var module = await Module();
+        await module.InvokeVoidAsync("clear", cancellationToken, elementId);
+    }
+
+    private sealed class CallbackInvoker
+    {
+        private readonly EventCallback<string> _callback;
+        public CallbackInvoker(EventCallback<string> callback) { _callback = callback; }
+        [JSInvokable]
+        public Task Invoke(string json) => _callback.InvokeAsync(json);
     }
 }

--- a/src/Options/DrawflowOptions.cs
+++ b/src/Options/DrawflowOptions.cs
@@ -1,0 +1,31 @@
+namespace Soenneker.Blazor.Drawflow.Options;
+
+/// <summary>
+/// Options for initializing a Drawflow instance.
+/// These mirror common properties found in the JavaScript library.
+/// </summary>
+public class DrawflowOptions
+{
+    /// <summary>Enables connection rerouting.</summary>
+    public bool Reroute { get; set; } = false;
+
+    public bool RerouteFixCurvature { get; set; } = false;
+
+    public double Curvature { get; set; } = 0.5;
+    public double RerouteCurvatureStartEnd { get; set; } = 0.5;
+    public double RerouteCurvature { get; set; } = 0.5;
+    public int RerouteWidth { get; set; } = 6;
+    public int LinePath { get; set; } = 5;
+    public bool ForceFirstInput { get; set; } = false;
+    public string EditorMode { get; set; } = "edit";
+    public double Zoom { get; set; } = 1;
+    public double ZoomMax { get; set; } = 1.6;
+    public double ZoomMin { get; set; } = 0.5;
+    public double ZoomValue { get; set; } = 0.1;
+    public double ZoomLastValue { get; set; } = 1;
+    public bool DraggableInputs { get; set; } = true;
+    public bool UseUuid { get; set; } = false;
+
+    /// <summary>Whether CDN links should be used when injecting scripts.</summary>
+    public bool UseCdn { get; set; } = true;
+}

--- a/src/wwwroot/js/drawflowinterop.js
+++ b/src/wwwroot/js/drawflowinterop.js
@@ -1,3 +1,150 @@
-﻿window.initdrawflowinterop = (params) => {
+export class DrawflowInterop {
+    constructor() {
+        this.instances = {};
+    }
 
-};
+    create(elementId, options) {
+        const selector = `[blazor-interop-id="${elementId}"]`;
+        const container = document.querySelector(selector);
+        const editor = new Drawflow(container);
+        if (options) {
+            Object.assign(editor, options);
+        }
+        editor.start();
+        this.instances[elementId] = editor;
+    }
+
+    addNode(elementId, name, inputs, outputs, posX, posY, className, data, html) {
+        const editor = this.instances[elementId];
+        return editor.addNode(name, inputs, outputs, posX, posY, className, data, html);
+    }
+
+    removeNode(elementId, id) {
+        const editor = this.instances[elementId];
+        editor.removeNodeId(id);
+    }
+
+    addConnection(elementId, outId, inId, outClass, inClass) {
+        const editor = this.instances[elementId];
+        editor.addConnection(outId, inId, outClass, inClass);
+    }
+
+    export(elementId) {
+        const editor = this.instances[elementId];
+        const data = editor.export();
+        return JSON.stringify(data);
+    }
+
+    import(elementId, json) {
+        const editor = this.instances[elementId];
+        editor.import(JSON.parse(json));
+    }
+
+    destroy(elementId) {
+        const editor = this.instances[elementId];
+        if (editor) {
+            editor.destroy();
+            delete this.instances[elementId];
+        }
+    }
+
+    addEventListener(elementId, eventName, dotNetCallback) {
+        const editor = this.instances[elementId];
+        editor.on(eventName, (...args) => {
+            const json = JSON.stringify(args);
+            dotNetCallback.invokeMethodAsync('Invoke', json);
+        });
+    }
+
+    zoomIn(elementId) {
+        const editor = this.instances[elementId];
+        editor.zoom_in();
+    }
+
+    zoomOut(elementId) {
+        const editor = this.instances[elementId];
+        editor.zoom_out();
+    }
+
+    addModule(elementId, name) {
+        const editor = this.instances[elementId];
+        editor.addModule(name);
+    }
+
+    changeModule(elementId, name) {
+        const editor = this.instances[elementId];
+        editor.changeModule(name);
+    }
+
+    removeModule(elementId, name) {
+        const editor = this.instances[elementId];
+        editor.removeModule(name);
+    }
+
+    getNodeFromId(elementId, id) {
+        const editor = this.instances[elementId];
+        return editor.getNodeFromId(id);
+    }
+
+    getNodesFromName(elementId, name) {
+        const editor = this.instances[elementId];
+        return editor.getNodesFromName(name);
+    }
+
+    updateNodeData(elementId, id, data) {
+        const editor = this.instances[elementId];
+        editor.updateNodeDataFromId(id, data);
+    }
+
+    addNodeInput(elementId, id) {
+        const editor = this.instances[elementId];
+        editor.addNodeInput(id);
+    }
+
+    addNodeOutput(elementId, id) {
+        const editor = this.instances[elementId];
+        editor.addNodeOutput(id);
+    }
+
+    removeNodeInput(elementId, id, inputClass) {
+        const editor = this.instances[elementId];
+        editor.removeNodeInput(id, inputClass);
+    }
+
+    removeNodeOutput(elementId, id, outputClass) {
+        const editor = this.instances[elementId];
+        editor.removeNodeOutput(id, outputClass);
+    }
+
+    removeSingleConnection(elementId, outId, inId, outClass, inClass) {
+        const editor = this.instances[elementId];
+        editor.removeSingleConnection(outId, inId, outClass, inClass);
+    }
+
+    updateConnectionNodes(elementId, id) {
+        const editor = this.instances[elementId];
+        editor.updateConnectionNodes(id);
+    }
+
+    removeConnectionNodeId(elementId, id) {
+        const editor = this.instances[elementId];
+        editor.removeConnectionNodeId(id);
+    }
+
+    getModuleFromNodeId(elementId, id) {
+        const editor = this.instances[elementId];
+        return editor.getModuleFromNodeId(id);
+    }
+
+    clearModuleSelected(elementId) {
+        const editor = this.instances[elementId];
+        editor.clearModuleSelected();
+    }
+
+    clear(elementId) {
+        const editor = this.instances[elementId];
+        editor.clear();
+    }
+}
+
+window.DrawflowInterop = new DrawflowInterop();

--- a/test/Soenneker.Blazor.Drawflow.Demo/Pages/Index.razor
+++ b/test/Soenneker.Blazor.Drawflow.Demo/Pages/Index.razor
@@ -1,18 +1,43 @@
-﻿@page "/"
-@using Microsoft.Extensions.Logging
-
+@page "/"
+@using Soenneker.Blazor.Drawflow.Options
+@using Soenneker.Blazor.Drawflow
 @inject ILogger<Index> Logger
 
-<img src="https://user-images.githubusercontent.com/4441470/224455560-91ed3ee7-f510-4041-a8d2-3fc093025112.png" />
 <h1>Soenneker.Blazor.Drawflow demo</h1>
-<p>This page demonstrates some of the common usages for the interop library.</p>
-<br />
 
-<hr />
+<Drawflow @ref="_flow" Options="_options" OnNodeCreated="HandleCreated" style="height:500px;border:1px solid gray"></Drawflow>
 
-@code{
+<button class="btn btn-primary" @onclick="AddSample">Add Node</button>
+<button class="btn btn-secondary ms-2" @onclick="ZoomIn">Zoom In</button>
+<button class="btn btn-secondary ms-2" @onclick="AddModuleClick">Add Module</button>
 
-    protected override void OnInitialized()
+@code {
+    private Drawflow? _flow;
+    private readonly DrawflowOptions _options = new();
+
+    private Task HandleCreated(string id)
     {
+        Logger.LogInformation("Node created {Id}", id);
+        return Task.CompletedTask;
+    }
+
+    private async Task AddSample()
+    {
+        if (_flow != null)
+        {
+            await _flow.AddNode("github", 0, 1, 150, 150, "github", new { }, "<div>node</div>");
+        }
+    }
+
+    private async Task ZoomIn()
+    {
+        if (_flow != null)
+            await _flow.ZoomIn();
+    }
+
+    private async Task AddModuleClick()
+    {
+        if (_flow != null)
+            await _flow.AddModule("Other");
     }
 }

--- a/test/Soenneker.Blazor.Drawflow.Demo/wwwroot/index.html
+++ b/test/Soenneker.Blazor.Drawflow.Demo/wwwroot/index.html
@@ -10,6 +10,7 @@
 
     <link href="_content/Blazorise/blazorise.css" rel="stylesheet" />
     <link href="_content/Blazorise.Bootstrap/blazorise.bootstrap.css" rel="stylesheet" />
+    <link href="https://cdn.jsdelivr.net/npm/drawflow/dist/drawflow.min.css" rel="stylesheet" />
 </head>
 
 <body>
@@ -22,6 +23,7 @@
     </div>
 
     <script src="_framework/blazor.webassembly.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/drawflow/dist/drawflow.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.min.js"></script>
 </body>
 


### PR DESCRIPTION
## Summary
- add wrappers for most Drawflow.js API methods
- expose new helpers via the Blazor component
- document advanced usage
- extend the demo to exercise new calls

## Testing
- `dotnet build --no-restore src/Soenneker.Blazor.Drawflow.csproj -c Release`
- `dotnet test test/Soenneker.Blazor.Drawflow.Tests/Soenneker.Blazor.Drawflow.Tests.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_6863189e16888325b2279a22d685101b